### PR TITLE
Bug in README with link to image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="/docs/images/RTKlogo-small.png" width="148"/>
+<img src="/docs/assets/images/RTKlogo-small.png" width="148"/>
 
 # RSE Toolkit: The Research Software Engineer's Toolkit
 


### PR DESCRIPTION
This fixes a path error in the README for the toolkit logo.