### PR TITLE
Add redirect from rse-competencies-toolkit to new DIRECT framework site

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -15,7 +15,7 @@ source "https://rubygems.org"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
-gem "github-pages", "~> 211", group: :jekyll_plugins
+gem "github-pages", "~> 232", group: :jekyll_plugins
 gem "jekyll-include-cache", group: :jekyll_plugins
 
 # If you have any plugins, put them here!

--- a/docs/_layouts/redirect.html
+++ b/docs/_layouts/redirect.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Redirect to {{ page.target }}</title>
+    <meta http-equiv="refresh" content="0;url={{ page.target }}"/>
+  </head>
+<body>
+    <p>Redirecting to
+    <a href="{{ page.target }}">{{ page.target }}</a>...</p>
+</body>
+</html>

--- a/docs/_pages/rse-competencies-toolkit.md
+++ b/docs/_pages/rse-competencies-toolkit.md
@@ -1,0 +1,5 @@
+---
+permalink: /rse-competencies-toolkit/
+layout: redirect
+target: https://direct-framework.github.io/digital-research-competencies-framework/
+---


### PR DESCRIPTION
The `rse-competencies-toolkit` repo was recently moved to https://github.com/direct-framework/digital-research-competencies-framework after the project was renamed. The old site https://rsetoolkit.github.io/rse-competencies-toolkit/ now gives a 404 as the GitHub Pages site also migrated (to https://direct-framework.github.io/digital-research-competencies-framework/)

This PR sets up a redirect within the base rsetoolkit.github.io site so that the old link will redirect to the new site. I also had to update the `github-pages` gem as there was a bug when I built the site locally.

Happy to change the location of `rse-competencies-toolkit.md` according to the preference of the maintainers :)